### PR TITLE
Add alt text to Dev Skills icon image

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p>
   <a href="https://skillicons.dev">
-    <img src="https://skillicons.dev/icons?i=ruby,rails,postgresql,git,github,javascript,react,nodejs,html,css,figma,aws" />
+    <img src="https://skillicons.dev/icons?i=ruby,rails,postgresql,git,github,javascript,react,nodejs,html,css,figma,aws" alt="Íconos de habilidades" />
   </a>
 </p>
 


### PR DESCRIPTION
## Summary
- add descriptive alt text to Dev Skills icon image in README

## Testing
- `python - <<'PY'
import html5lib
snippet = """
<p>
  <a href=\"https://skillicons.dev\">
    <img src=\"https://skillicons.dev/icons?i=ruby,rails,postgresql,git,github,javascript,react,nodejs,html,css,figma,aws\" alt=\"Íconos de habilidades\" />
  </a>
</p>
"""
try:
    html5lib.parseFragment(snippet)
    print('HTML snippet is valid')
except Exception as e:
    print('HTML parse error:', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689a591337a083279a36444725ae0909